### PR TITLE
pass through descriptions alongside interfaces

### DIFF
--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -73,10 +73,8 @@ impl Nullable for Schema {
 fn allowing_null_turns_refs_into_oneof() {
     use super::ref_or::Ref;
 
-    let schema = RefOr::<BasicSchema>::Ref(Ref::new(
-        "#/components/schemas/widget",
-        BTreeMap::new(),
-    ));
+    let schema =
+        RefOr::<BasicSchema>::Ref(Ref::new("#/components/schemas/widget", None));
     assert_eq!(
         schema.allowing_null(),
         RefOr::Value(BasicSchema::OneOf(OneOf::new(

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -73,7 +73,10 @@ impl Nullable for Schema {
 fn allowing_null_turns_refs_into_oneof() {
     use super::ref_or::Ref;
 
-    let schema = RefOr::<BasicSchema>::Ref(Ref::new("#/components/schemas/widget"));
+    let schema = RefOr::<BasicSchema>::Ref(Ref::new(
+        "#/components/schemas/widget",
+        BTreeMap::new(),
+    ));
     assert_eq!(
         schema.allowing_null(),
         RefOr::Value(BasicSchema::OneOf(OneOf::new(


### PR DESCRIPTION
ReadMe and the OpenApi spec as well as a [maintainer](https://github.com/OAI/OpenAPI-Specification/issues/1514#issuecomment-1092937505) all say that as of 3.1 it is supported to provide a `description` alongside a `$ref`. 

> Additionally, as of OpenAPI 3.1, you can include summary and description fields in addition to the $ref pointer, [which will override the summary and description fields of the referenced component](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#fixed-fields-19). Everything else will be fully deferenced.

I modified the code to pass through the description field for `interfaces`. Any other fields will be rejected and error. This enables use to just use a `description` field instead of the union workaround below, which was causing issues with the generated client library.

```
schema:
     allOf:              
              - $interface: "IdentitySets#SameAsInterface"
              - type: "object"
                description: "test ref description"
```
can now be:
```
schema:
     $interface: "IdentitySets#SameAsInterface"
     description: "test ref description"
```

I verified that the generated code renders as expected in Readme and plays nicely with `openapi-typescript`. This resolves these two issues that Blake reported: #3 #2 