### PR TITLE
Add fancy `title` and `description` to Merge Patch docs

### DIFF
--- a/examples/example_output.yml
+++ b/examples/example_output.yml
@@ -41,7 +41,11 @@ components:
         comment:
           oneOf:
             - type: string
+              title: "Overwrite"
+              description: "Pass this value to overwrite the existing value."
             - type: "null"
+              title: "Clear"
+              description: "Pass `null` to clear this field's existing value."
         name:
           type: string
       additionalProperties: false

--- a/examples/long_example.yml
+++ b/examples/long_example.yml
@@ -118,6 +118,7 @@ components:
         name:
           mutable: true
           schema:
+            description: "The name of this widget."
             type: string
         vendor_id:
           required: true

--- a/examples/long_example_output.yml
+++ b/examples/long_example_output.yml
@@ -78,6 +78,7 @@ components:
         sku:
           type: string
         name:
+          description: "The name of this widget."
           type: string
         vendor_id:
           type: string
@@ -95,6 +96,7 @@ components:
         sku:
           type: string
         name:
+          description: "The name of this widget."
           type: string
         vendor_id:
           type: string
@@ -108,6 +110,7 @@ components:
         - metadata
       properties:
         name:
+          description: "The name of this widget."
           type: string
         metadata:
           $ref: "#/components/schemas/MetadataPut"
@@ -116,9 +119,14 @@ components:
       type: object
       properties:
         name:
+          description: "The name of this widget."
           oneOf:
             - type: string
+              title: "Overwrite"
+              description: "Pass this value to overwrite the existing value."
             - type: "null"
+              title: "Clear"
+              description: "Pass `null` to clear this field's existing value."
         metadata:
           $ref: "#/components/schemas/MetadataMergePatch"
       additionalProperties: false

--- a/src/openapi/interface.rs
+++ b/src/openapi/interface.rs
@@ -444,7 +444,8 @@ fn generates_generic_merge_patch_types_when_necessary() {
             required: false,
             mutable: true,
             initializable: None,
-            schema: Schema::null(),
+            // Literally any schema would work here.
+            schema: Schema::new_schema_matching_only_null_for_merge_patch(),
         },
     );
     let iface = BasicInterface {
@@ -538,7 +539,7 @@ impl Member {
                     Some(schema)
                 } else {
                     // Optional fields become nullable.
-                    Some(schema.allowing_null_for_merge_patch())
+                    Some(schema.new_schema_matching_current_or_null_for_merge_patch())
                 }
             }
             InterfaceVariant::MergePatch => None,

--- a/src/openapi/interface.rs
+++ b/src/openapi/interface.rs
@@ -363,6 +363,7 @@ impl GenerateSchemaVariant for BasicInterface {
                     "A patch to `{}Put` in JSON Merge Patch format (RFC 7396).",
                     name
                 )),
+                title: None,
                 example: None,
                 unknown_fields: BTreeMap::default(),
             };
@@ -426,6 +427,7 @@ impl GenerateSchemaVariant for BasicInterface {
             items: None,
             nullable: None,
             description,
+            title: None,
             example,
             unknown_fields: BTreeMap::default(),
         };
@@ -536,7 +538,7 @@ impl Member {
                     Some(schema)
                 } else {
                     // Optional fields become nullable.
-                    Some(schema.allowing_null())
+                    Some(schema.allowing_null_for_merge_patch())
                 }
             }
             InterfaceVariant::MergePatch => None,
@@ -578,6 +580,7 @@ impl GenerateSchemaVariant for OneOfInterface {
 
         Ok(Schema::Value(BasicSchema::OneOf(OneOf {
             schemas,
+            description: None,
             discriminator,
             unknown_fields: Default::default(),
         })))


### PR DESCRIPTION
This was proposed by Blake as a way to get much nicer documentation using Readme.com.

Left to do:

- [x] Refactor the `Nullable` interface so it makes some kind of semi-coherent sense again.

Co-authored-by: Hana Kessler <hanakslr@users.noreply.github.com>