### PR TITLE
title, discriminator, and description fixes for interfaces

### DIFF
--- a/examples/long_example.yml
+++ b/examples/long_example.yml
@@ -100,6 +100,9 @@ components:
             $ref: "#/components/schemas/ResourceStatus"
     Widget:
       $includes: "Resource"
+      # On optional title field, used when the resource name doesn't match the 
+      # desired user-facing name in documentation.
+      title: "Widgetter"
       members:
         id:
           schema:

--- a/examples/long_example_output.yml
+++ b/examples/long_example_output.yml
@@ -54,6 +54,7 @@ components:
         - error
     Widget:
       type: object
+      title: "Widgetter"
       required:
         - created_at
         - id

--- a/examples/oneof_example_output.yml
+++ b/examples/oneof_example_output.yml
@@ -4,6 +4,7 @@ paths: {}
 components:
   schemas:
     ShapeOptions:
+      description: "Options for a shape."
       oneOf:
         - $ref: "#/components/schemas/SquareShapeOptions"
         - $ref: "#/components/schemas/RoundShapeOptions"
@@ -14,6 +15,7 @@ components:
           round: "#/components/schemas/RoundShapeOptions"
 
     ShapeOptionsMergePatch:
+      description: "Options for a shape."
       oneOf:
         - $ref: "#/components/schemas/SquareShapeOptionsMergePatch"
         - $ref: "#/components/schemas/RoundShapeOptionsMergePatch"
@@ -24,6 +26,7 @@ components:
           round: "#/components/schemas/RoundShapeOptionsMergePatch"
 
     ShapeOptionsPost:
+      description: "Options for a shape."
       oneOf:
         - $ref: "#/components/schemas/SquareShapeOptionsPost"
         - $ref: "#/components/schemas/RoundShapeOptionsPost"
@@ -34,6 +37,7 @@ components:
           round: "#/components/schemas/RoundShapeOptionsPost"
 
     ShapeOptionsPut:
+      description: "Options for a shape."
       oneOf:
         - $ref: "#/components/schemas/SquareShapeOptionsPut"
         - $ref: "#/components/schemas/RoundShapeOptionsPut"

--- a/src/openapi/interface.rs
+++ b/src/openapi/interface.rs
@@ -581,7 +581,7 @@ impl GenerateSchemaVariant for OneOfInterface {
 
         Ok(Schema::Value(BasicSchema::OneOf(OneOf {
             schemas,
-            description: None,
+            description: self.description.clone(),
             discriminator,
             unknown_fields: Default::default(),
         })))

--- a/src/openapi/interface.rs
+++ b/src/openapi/interface.rs
@@ -325,6 +325,12 @@ pub struct BasicInterface {
     #[serde(default)]
     description: Option<String>,
 
+    /// An optional human-readable title. Used in documentation
+    /// for cases where the resource name, which is generally used
+    /// by default, is not desired.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
     /// Example data for this type.
     ///
     /// TODO: We'll need multiple versions for different variants, sadly.
@@ -410,6 +416,13 @@ impl GenerateSchemaVariant for BasicInterface {
             None
         };
 
+        // TODO: Only include the title on the base type for now.
+        let title = if variant == InterfaceVariant::Get {
+            self.title.clone()
+        } else {
+            None
+        };
+
         // TODO: Only include the example on the POST type now. We **will**
         // break this.
         let example = if variant == InterfaceVariant::Post {
@@ -427,7 +440,7 @@ impl GenerateSchemaVariant for BasicInterface {
             items: None,
             nullable: None,
             description,
-            title: None,
+            title,
             example,
             unknown_fields: BTreeMap::default(),
         };
@@ -453,6 +466,7 @@ fn generates_generic_merge_patch_types_when_necessary() {
         members,
         additional_members: None,
         description: None,
+        title: None,
         example: None,
     };
 
@@ -555,6 +569,12 @@ pub struct OneOfInterface {
     #[serde(default)]
     description: Option<String>,
 
+    /// An optional human-readable title. Used in documentation
+    /// for cases where the resource name, which is generally used
+    /// by default, is not desired.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
     /// Allowable types that can be used for this interface.
     one_of: Vec<Schema>,
 
@@ -582,6 +602,7 @@ impl GenerateSchemaVariant for OneOfInterface {
         Ok(Schema::Value(BasicSchema::OneOf(OneOf {
             schemas,
             description: self.description.clone(),
+            title: self.title.clone(),
             discriminator,
             unknown_fields: Default::default(),
         })))

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -101,6 +101,7 @@ fn allowing_null_turns_refs_into_oneof() {
                 Schema::new_schema_matching_only_null_for_merge_patch()
             ],
             description: None,
+            title: None,
             discriminator: None,
             unknown_fields: Default::default(),
         }))
@@ -302,6 +303,12 @@ pub struct OneOf {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
 
+    /// An optional human-readable title. Used in documentation
+    /// for cases where the resource name, which is generally used
+    /// by default, is not desired.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
     /// How to differentiate between our child schemas.
     pub discriminator: Option<Discriminator>,
 
@@ -323,6 +330,7 @@ impl OneOf {
         OneOf {
             schemas,
             description,
+            title: None,
             discriminator: None,
             unknown_fields: Default::default(),
         }
@@ -336,6 +344,7 @@ impl Transpile for OneOf {
         Ok(Self {
             schemas: self.schemas.transpile(scope)?,
             description: self.description.clone(),
+            title: self.title.clone(),
             discriminator: self.discriminator.clone(),
             unknown_fields: self.unknown_fields.clone(),
         })

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -310,6 +310,7 @@ pub struct OneOf {
     pub title: Option<String>,
 
     /// How to differentiate between our child schemas.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<Discriminator>,
 
     /// YAML fields we want to pass through blindly.


### PR DESCRIPTION
- Allow a `title` field on interfaces (allowed in spec [here](https://swagger.io/specification/#:~:text=the%20same%20specifications%3A-,title,-multipleOf))
- Only include `discriminator` if it is not none
- Pass through `description` from interfaces

Resolves issues #10 #11 #12 
