### PR TITLE
Add support for `$includeFiles` (fixes #24)

### DIFF
--- a/examples/include_files/base.yml
+++ b/examples/include_files/base.yml
@@ -1,0 +1,36 @@
+# An example file which includes definitions from several external files.
+
+openapi: "3.1.0"
+info:
+  title: Example OpenAPI definition
+$includeFiles:
+  - "paths.yml"
+  - "core_components.yml"
+paths: {}
+components:
+  interfaces:
+    Widget:
+      # Include all fields from `Resource`.
+      $includes: "Resource"
+      description: |
+        A displayable widget.
+      members:
+        name:
+          required: true
+          mutable: true
+          schema:
+            type: string
+        comment:
+          mutable: true
+          schema:
+            type: string
+        readonly:
+          required: true
+          # This can't be updated once the object is created.
+          mutable: false
+          # But we do allow this to be set at creation time.
+          # If omitted, `initializable` defaults to the value
+          # of the `mutable` option.
+          initializable: true
+          schema:
+            type: string

--- a/examples/include_files/core_components.yml
+++ b/examples/include_files/core_components.yml
@@ -1,0 +1,18 @@
+# External definitions of some components.
+
+openapi: "3.1.0"
+
+components:
+  schemas:
+    Uuid:
+      type: string
+      format: uuid
+
+  interfaces:
+    Resource:
+      emit: false
+      members:
+        id:
+          required: true
+          schema:
+            $ref: "#/components/schemas/Uuid"

--- a/examples/include_files/output.yml
+++ b/examples/include_files/output.yml
@@ -1,0 +1,83 @@
+# AUTOMATICALLY GENERATED. DO NOT EDIT.
+---
+openapi: 3.1.0
+paths:
+  /widgets:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WidgetPost"
+        required: true
+      responses:
+        201:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Widget"
+components:
+  schemas:
+    Uuid:
+      type: string
+      format: uuid
+    Widget:
+      type: object
+      required:
+        - id
+        - name
+        - readonly
+      properties:
+        comment:
+          type: string
+        id:
+          $ref: "#/components/schemas/Uuid"
+        name:
+          type: string
+        readonly:
+          type: string
+      additionalProperties: false
+      description: "A displayable widget.\n"
+    WidgetMergePatch:
+      type: object
+      properties:
+        comment:
+          type: ~
+          oneOf:
+            - type: string
+              description: Pass this value to overwrite the existing value.
+              title: Overwrite
+            - type: "null"
+              description: "Pass `null` to clear this field's existing value."
+              title: Clear
+        name:
+          type: string
+      additionalProperties: false
+      description: "(Parameters used to PATCH the `Widget` type.)\n\nA displayable widget.\n"
+    WidgetPost:
+      type: object
+      required:
+        - name
+        - readonly
+      properties:
+        comment:
+          type: string
+        name:
+          type: string
+        readonly:
+          type: string
+      additionalProperties: false
+      description: "(Parameters used to POST a new value of the `Widget` type.)\n\nA displayable widget.\n"
+    WidgetPut:
+      type: object
+      required:
+        - name
+      properties:
+        comment:
+          type: string
+        name:
+          type: string
+      additionalProperties: false
+      description: "(Parameters used to PUT a value of the `Widget` type.)\n\nA displayable widget.\n"
+info:
+  title: Example OpenAPI definition

--- a/examples/include_files/paths.yml
+++ b/examples/include_files/paths.yml
@@ -1,0 +1,19 @@
+# External path definitions.
+
+openapi: "3.1.0"
+
+paths:
+  /widgets:
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $interface: "Widget#Post"
+      responses:
+        201:
+          content:
+            application/json:
+              schema:
+                $interface: "Widget"

--- a/src/openapi/included_files.rs
+++ b/src/openapi/included_files.rs
@@ -1,0 +1,214 @@
+//! Keeping track of multiple files.
+//!
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env::current_dir,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{format_err, Context};
+use log::debug;
+
+use super::OpenApi;
+use crate::Result;
+
+/// Resolve all `$includedFiles` that appear in `base`, recursively.
+pub fn resolve_included_files(base: &mut OpenApi, base_path: &Path) -> Result<()> {
+    let mut included = IncludedFiles::default();
+    included.process_includes(base, base_path)?;
+    included.merge_into_base(base, base_path)
+}
+
+/// All the OpenAPI files mentioned in any `$includedFiles` lists.
+#[derive(Debug, Default)]
+struct IncludedFiles {
+    /// Mapping from path names to parsed files.
+    ///
+    /// Pathnames should be relative to the current working directory, not the
+    /// file they originally appeared in.
+    included_files: BTreeMap<PathBuf, Option<OpenApi>>,
+}
+
+impl IncludedFiles {
+    /// Process all includes in `from` recursively, using `base_path` as
+    /// the base for all the paths.
+    fn process_includes(&mut self, base: &OpenApi, base_path: &Path) -> Result<()> {
+        for path in &base.include_files {
+            // Construct a relative path (which may include messy things like
+            // "..") and make sure it points to a real file.
+            let messy_relative_path = base_path
+                .parent()
+                .ok_or_else(|| {
+                    format_err!(
+                        "cannot find parent directory of {}",
+                        base_path.display()
+                    )
+                })?
+                .join(path);
+            if !&messy_relative_path.exists() {
+                return Err(format_err!(
+                    "cannot find file {}",
+                    messy_relative_path.display()
+                ));
+            }
+
+            // First construct an absolute path pointing to our input file, so
+            // that tricky mixes of symlinks and "../" path segments don't
+            // confuse us into include the same file using two equivalent
+            // relative paths.
+            let absolute_path = messy_relative_path
+                // Make an absolute path, getting rid of symlinks, etc.
+                .canonicalize()
+                .context("cannot determine absolute path")?;
+
+            // Then make the path relative to the `cwd` if we can, just to be
+            // nice.
+            let cwd = current_dir().context("can't get current directory")?;
+            let cwd_relative_path = absolute_path
+                // Try to make it relative.
+                .strip_prefix(cwd)
+                // If we succeed, make sure we own it, so we drop all borrows of
+                // `abs_path`.
+                .map(|p| p.to_owned())
+                // If we failed, just use `abs_path`.
+                .unwrap_or(absolute_path);
+
+            self.include_file(cwd_relative_path)?;
+        }
+        Ok(())
+    }
+
+    /// Include a new file.
+    fn include_file(&mut self, normalized_path: PathBuf) -> Result<()> {
+        match self.included_files.get(&normalized_path) {
+            Some(None) => Err(format_err!(
+                "tried to load {} while we were already loading it, do you have circular includes?",
+                normalized_path.display()
+            )),
+            Some(Some(_)) => {
+                debug!("already included {}, skipping", normalized_path.display());
+                Ok(())
+            },
+            None => {
+                // Indicate that we know about this file but haven't finished
+                // loading it yet.
+                self.included_files.insert(normalized_path.to_owned(), None);
+
+                // Load the file.
+                let parsed = OpenApi::from_path(&normalized_path)
+                    .with_context(|| {
+                        format!("error while trying to load {}", normalized_path.display())
+                    })?;
+
+                // Process any includes recusively.
+                self.process_includes(&parsed, &normalized_path)?;
+
+                // Store our parsed file
+                self.included_files.insert(normalized_path, Some(parsed));
+                Ok(())
+            },
+        }
+    }
+
+    /// Take all the files we know about, and merge them into `base`.
+    ///
+    /// The is a very conservative function. It doesn't do any of the funky JSON
+    /// Merge Path stuff supported by `$include` (because doing that across
+    /// files would be confusing). And it errors on duplicate definitions and
+    /// conflicts.
+    fn merge_into_base(&self, base: &mut OpenApi, base_path: &Path) -> Result<()> {
+        for (included_path, included) in &self.included_files {
+            let included = included.as_ref().ok_or_else(|| {
+                format_err!(
+                    "failed to finishing loading {}, so we can't merge it",
+                    included_path.display()
+                )
+            })?;
+
+            // Merge `paths`.
+            for (path, methods) in &included.paths {
+                if base
+                    .paths
+                    .insert(path.to_owned(), methods.to_owned())
+                    .is_some()
+                {
+                    return Err(format_err!(
+                        "duplicate definitions of `paths[{:?}]` in {} and {}",
+                        path,
+                        base_path.display(),
+                        included_path.display()
+                    ));
+                }
+            }
+
+            // Merge `components.schemas`.
+            for (name, schema) in &included.components.schemas {
+                if base
+                    .components
+                    .schemas
+                    .insert(name.to_owned(), schema.to_owned())
+                    .is_some()
+                {
+                    return Err(format_err!(
+                        "duplicate definitions of `components.schemas.{}` in {} and {}",
+                        name,
+                        base_path.display(),
+                        included_path.display()
+                    ));
+                }
+            }
+
+            // Merge `components.interfaces`.
+            for (name, iface) in &*included.components.interfaces {
+                if base
+                    .components
+                    .interfaces
+                    .insert(name.to_owned(), iface.to_owned())
+                    .is_some()
+                {
+                    return Err(format_err!(
+                        "duplicate definitions of `components.interfaces.{}` in {} and {}",
+                        name,
+                        base_path.display(),
+                        included_path.display()
+                    ));
+                }
+            }
+
+            // Fail if there are any other values we don't know how to merge.
+            if !included.unknown_fields.is_empty() {
+                let keys = included
+                    .unknown_fields
+                    .keys()
+                    // Avoid generating code just for `BTreeSet<&String>`.
+                    .cloned()
+                    .collect::<BTreeSet<String>>();
+                return Err(format_err!(
+                    "cannot specify {:?} in included file {} (put it in {} instead)",
+                    keys,
+                    included_path.display(),
+                    base_path.display(),
+                ));
+            }
+            if !included.components.unknown_fields.is_empty() {
+                let keys = included
+                    .components
+                    .unknown_fields
+                    .keys()
+                    .map(|k| format!("components.{}", k))
+                    .collect::<BTreeSet<String>>();
+                return Err(format_err!(
+                    "cannot specify {:?} in included file {} (put it in {} instead)",
+                    keys,
+                    included_path.display(),
+                    base_path.display(),
+                ));
+            }
+        }
+
+        // And remove our inclusion declarations, now that we no longer need
+        // them.
+        base.include_files.clear();
+        Ok(())
+    }
+}

--- a/src/openapi/interface.rs
+++ b/src/openapi/interface.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ops::{Deref, DerefMut},
     str::FromStr,
 };
 
@@ -155,6 +156,24 @@ impl Interfaces {
             }
         }
         Ok(interfaces)
+    }
+}
+
+// Pretend that we're a basically a smart pointer to the underlying `BTreeMap`,
+// so that we can be treated as such.
+impl Deref for Interfaces {
+    type Target = BTreeMap<String, Interface>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// Pretend that we're a basically a mutable smart pointer to the underlying
+// `BTreeMap`, so that we can be treated as such.
+impl DerefMut for Interfaces {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -796,8 +815,8 @@ fn parses_one_of_example() {
     use pretty_assertions::assert_eq;
     use std::path::Path;
 
-    let parsed =
-        OpenApi::from_path(Path::new("./examples/oneof_example.yml")).unwrap();
+    let path = Path::new("./examples/oneof_example.yml").to_owned();
+    let parsed = OpenApi::from_path(&path).unwrap();
     //println!("{:#?}", parsed);
     let transpiled = parsed.transpile(&Scope::default()).unwrap();
     println!("{}", serde_yaml::to_string(&transpiled).unwrap());

--- a/src/openapi/ref_or.rs
+++ b/src/openapi/ref_or.rs
@@ -135,7 +135,10 @@ impl Transpile for Ref {
 
     fn transpile(&self, _scope: &Scope) -> anyhow::Result<Self::Output> {
         if !self.unknown_fields.is_empty() {
-            return Err(format_err!("`$ref:` no unknown sibling values allowed"));
+            return Err(format_err!(
+                "`$ref:` no unknown sibling values allowed in {:?}",
+                self
+            ));
         }
 
         Ok(self.clone())
@@ -171,7 +174,8 @@ impl Transpile for InterfaceRef {
         // This type is defined by us, so let's enforce this rule.
         if !self.unknown_fields.is_empty() {
             return Err(format_err!(
-                "`$interface:` no unknown sibling values allowed"
+                "`$interface:` no unknown sibling values allowed in {:?}",
+                self
             ));
         }
 


### PR DESCRIPTION
This can be used to merge several input files into a single output file.

Merging happens after parsing but before transpiling. It merges named
definitions as complete entities, and not the raw YAML.
