### PR TITLE
Support 3.0.X nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `--avoid-type-null` is now deprecated, and acts as an alias for `--use_nullable_for_merge_patch`. This flag now generates complete OpenAPI 3.0-compatible MergePatch types using a clever hack based on `nullable: true` and `oneOf:`. It also now sets the file version number to `openapi: 3.0.0` when used, because 3.1 does not support `nullable: true`.
+
 ## 0.3.0 - 2022-06-13
 
 ### Added

--- a/examples/example_nullable_fields.yml
+++ b/examples/example_nullable_fields.yml
@@ -1,0 +1,52 @@
+# Testing the --use-deprecated-nullable option
+
+openapi: "3.1.0"
+info:
+  title: Example OpenAPI definition
+components:
+  schemas:
+    Polygon:
+      type: object
+      properties:
+        name:
+          mutable: true
+          type: string
+        number_of_sides:
+          mutable: true
+          type: number
+
+  interfaces:
+    Resource:
+      emit: false # Do not include this in generated output.
+      members:
+        id:
+          required: true
+          schema:
+            type: string
+    Widget:
+      $includes: "Resource"
+      description: |
+        A displayable widget.
+      members:
+        # We can override properties from `Resource` using JSON
+        # Merge Patch syntax.
+        id:
+          schema:
+            example: e35a3c8d-5486-49ec-9b23-6747afc19570
+        name:
+          required: true
+          # We want to include a test for primitive types
+          mutable: true
+          schema:
+            type: string
+        comment:
+          mutable: true
+          schema:
+            type: string
+        shape:
+          # We also want to include a test for properties that are
+          # $refs. If mutable, this will be turned into a oneOf object
+          # where nullable: true.
+          mutable: true
+          schema:
+            $ref: "#/components/schemas/Polygon"

--- a/examples/example_nullable_fields_output.yml
+++ b/examples/example_nullable_fields_output.yml
@@ -1,0 +1,74 @@
+# AUTOMATICALLY GENERATED. DO NOT EDIT.
+---
+openapi: 3.0.0
+paths: {}
+components:
+  schemas:
+    Polygon:
+      type: object
+      properties:
+        name:
+          type: string
+          mutable: true
+        number_of_sides:
+          type: number
+          mutable: true
+    Widget:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        comment:
+          type: string
+        id:
+          type: string
+          example: e35a3c8d-5486-49ec-9b23-6747afc19570
+        name:
+          type: string
+        shape:
+          $ref: "#/components/schemas/Polygon"
+      additionalProperties: false
+      description: "A displayable widget.\n"
+    WidgetMergePatch:
+      type: object
+      properties:
+        comment:
+          type: string
+          nullable: true
+        name:
+          type: string
+        shape:
+          oneOf:
+            - $ref: "#/components/schemas/Polygon"
+          nullable: true
+      additionalProperties: false
+      description: "(Parameters used to PATCH the `Widget` type.)\n\nA displayable widget.\n"
+    WidgetPost:
+      type: object
+      required:
+        - name
+      properties:
+        comment:
+          type: string
+        name:
+          type: string
+        shape:
+          $ref: "#/components/schemas/Polygon"
+      additionalProperties: false
+      description: "(Parameters used to POST a new value of the `Widget` type.)\n\nA displayable widget.\n"
+    WidgetPut:
+      type: object
+      required:
+        - name
+      properties:
+        comment:
+          type: string
+        name:
+          type: string
+        shape:
+          $ref: "#/components/schemas/Polygon"
+      additionalProperties: false
+      description: "(Parameters used to PUT a value of the `Widget` type.)\n\nA displayable widget.\n"
+info:
+  title: Example OpenAPI definition

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,13 +28,10 @@ struct Opt {
     #[structopt(short = "o", long = "out-file")]
     output: Option<PathBuf>,
 
-    /// Do not introduce `type: "null"` in the output. This is automatic for
-    /// OpenAPI 3.0. This option will result in generic `MergePatch` types.
-    ///
-    /// Useful for compatibility with readme.com and other OpenAPI 3.0-only
-    /// tools.
-    #[structopt(long = "avoid-type-null")]
-    avoid_type_null: bool,
+    /// Do not introduce `type: "null"` in the output. Instead, use `nullable:
+    /// true` and set `openapi: "3.0.0"` in the output.
+    #[structopt(long = "use-nullable-for-merge-patch", alias = "avoid-type-null")]
+    use_nullable_for_merge_patch: bool,
 }
 
 /// Main entry point. Really just a wrapper for `run` which sets up logging and
@@ -59,9 +56,9 @@ fn main() {
 fn run(opt: &Opt) -> Result<()> {
     let mut openapi = OpenApi::from_path(&opt.input)?;
     let mut scope = Scope::default();
-    if !openapi.supports_type_null() || opt.avoid_type_null {
+    if !openapi.supports_type_null() || opt.use_nullable_for_merge_patch {
         // We don't support `type: "null"`, so don't introduce it.
-        scope.use_generic_merge_patch_types = true;
+        scope.use_nullable_for_merge_patch = true;
     }
     trace!("Parsed: {:#?}", openapi);
     resolve_included_files(&mut openapi, &opt.input)?;

--- a/src/openapi/transpile.rs
+++ b/src/openapi/transpile.rs
@@ -11,10 +11,9 @@ use super::interface::InterfaceVariant;
 /// scope" in a compiler for a regular programming language.
 #[non_exhaustive]
 pub struct Scope {
-    /// Do we want all merge patch types to have `type: object` and no further
-    /// constraints? This is necessary for Readme.com, which doesn't support
-    /// OpenAPI 3.1.0 or `type: "null"`.
-    pub use_generic_merge_patch_types: bool,
+    /// OpenApi 3.0.X indicated nullable fields via `nullable: true` whereas 3.1
+    /// uses `oneOf: { type: "null" }`. This boolean generates the 3.0 syntax.
+    pub use_nullable_for_merge_patch: bool,
 
     /// The `InterfaceVariant` of the containing interface.
     pub variant: Option<InterfaceVariant>,
@@ -25,7 +24,7 @@ impl Scope {
     /// variant.
     pub fn with_variant(&self, variant: InterfaceVariant) -> Scope {
         Self {
-            use_generic_merge_patch_types: self.use_generic_merge_patch_types,
+            use_nullable_for_merge_patch: self.use_nullable_for_merge_patch,
             variant: Some(variant),
         }
     }
@@ -35,7 +34,7 @@ impl Default for Scope {
     /// Create an empty default scope.
     fn default() -> Self {
         Self {
-            use_generic_merge_patch_types: false,
+            use_nullable_for_merge_patch: false,
             variant: None,
         }
     }


### PR DESCRIPTION
OpenAPI 3.0.X uses `nullable: true` as the way to indicate that a field is nullable. This is different that 3.1, which uses

```
oneOf:
- (the other types)
- type: null
```

However, some of our tooling is outdated, and requires the older usage to generate merge patches appropriately.

This PR adds a command line options `use-deprecated-nullable`.

## Pairing TODO

- [x] Pass `scope` through
- [x] Review CLI
- [x] What if input uses `nullable`?
